### PR TITLE
Add An Post (Ireland) delivery service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ United Kingdom:
 - Evri
 
 Europe:
+- An Post (IE)
 - Belpost (BY)
 - Magyar Posta (HU)
 - Packeta
@@ -22,7 +23,6 @@ Europe:
 - Sameday Bulgaria
 - Sameday Hungary
 - Sameday Romania
-- An Post (IE)
 
 Asia:
 - SPX Thailand

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Europe:
 - Sameday Bulgaria
 - Sameday Hungary
 - Sameday Romania
+- An Post (IE)
 
 Asia:
 - SPX Thailand

--- a/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
@@ -18,7 +18,7 @@ object AnPostDeliveryService : DeliveryService {
 
     override fun acceptsFormat(trackingId: String): Boolean {
         val anPostParcelFormat = """(?i)^[A-Z]{2}\d{9}IE$""".toRegex()
-        return anPostParcelFormat.matches(trackingId)
+        return anPostParcelFormat.matchEntire(trackingId) != null
     }
 
     // Public API key for request header

--- a/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dev.itsvic.parceltracker.api
+
+import dev.itsvic.parceltracker.R
+
+object AnPostDeliveryService : DeliveryService {
+    override val nameResource: Int = R.string.service_example
+    override val acceptsPostCode: Boolean = false
+    override val requiresPostCode: Boolean = false
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
@@ -17,7 +17,7 @@ object AnPostDeliveryService : DeliveryService {
     override val requiresPostCode: Boolean = false
 
     override fun acceptsFormat(trackingId: String): Boolean {
-        val anPostParcelFormat = """(?i)^[A-Z]{2}\d{9}IE$""".toRegex()
+        val anPostParcelFormat = """^[A-Z]{2}\d{9}IE$""".toRegex(RegexOption.IGNORE_CASE)
         return anPostParcelFormat.matchEntire(trackingId) != null
     }
 
@@ -130,7 +130,7 @@ object AnPostDeliveryService : DeliveryService {
             4 -> Status.OutForDelivery  // "Your item is out for delivery"
             13 -> Status.DeliveryFailure  // "We tried to deliver your item"
             14 -> Status.Delivered  // "Your item has been delivered"
-            else -> logUnknownStatus("AnPost", "TraceCode: $traceCode")
+            else -> logUnknownStatus("AnPost", traceCode.toString())
         }
     }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt
@@ -1,10 +1,136 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package dev.itsvic.parceltracker.api
 
+import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.HttpException
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 object AnPostDeliveryService : DeliveryService {
-    override val nameResource: Int = R.string.service_example
+    override val nameResource: Int = R.string.service_an_post
     override val acceptsPostCode: Boolean = false
     override val requiresPostCode: Boolean = false
+
+    override fun acceptsFormat(trackingId: String): Boolean {
+        val anPostParcelFormat = """(?i)^[A-Z]{2}\d{9}IE$""".toRegex()
+        return anPostParcelFormat.matches(trackingId)
+    }
+
+    // Public API key for request header
+    private val apiKey = "01b0162771e941639046a97936f72e95"
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl("https://apim-anpost-apwebapis.anpost.com/")
+        .client(api_client)
+        .addConverterFactory(api_factory)
+        .build()
+
+    private val service = retrofit.create(API::class.java)
+
+    private interface API {
+        @POST("ttservice-public-apweb/GetEvents")
+        suspend fun getEvents(
+            @Header("Ocp-Apim-Subscription-Key") key: String,
+            @Body request: GetEventsRequest
+        ): GetEventsResponse
+
+        @POST("ttservice-public-apweb/GetItemSummary")
+        suspend fun getItemSummary(
+            @Header("Ocp-Apim-Subscription-Key") key: String,
+            @Body request: GetItemSummaryRequest
+        ): GetItemSummaryResponse
+    }
+
+    @JsonClass(generateAdapter = true)
+    data class GetEventsRequest(val getEvents: GetEvents)
+
+    @JsonClass(generateAdapter = true)
+    data class GetEvents(val barcodeItem: String)
+
+    @JsonClass(generateAdapter = true)
+    data class GetEventsResponse(val getEventsResponse: GetEventsResponseData)
+
+    @JsonClass(generateAdapter = true)
+    data class GetEventsResponseData(val GetEventsResult: List<GetEventsResult>)
+
+    @JsonClass(generateAdapter = true)
+    data class GetEventsResult(
+        val activity: String,
+        val date: String,
+        val location: String,
+        val reason: String,
+        val traceCode: Int
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class GetItemSummaryRequest(val getItemSummary: GetItemSummary)
+
+    @JsonClass(generateAdapter = true)
+    data class GetItemSummary(val trackingItems: List<String>)
+
+    @JsonClass(generateAdapter = true)
+    data class GetItemSummaryResponse(val getItemSummaryResponse: GetItemSummaryResponseData)
+
+    @JsonClass(generateAdapter = true)
+    data class GetItemSummaryResponseData(val GetItemSummaryResult: List<GetItemSummaryResult>)
+
+    @JsonClass(generateAdapter = true)
+    data class GetItemSummaryResult(
+        val anPostNo: String,
+        val countryOfOrigin: String,
+        val date: String,
+        val deliveryRecordFlag: Boolean,
+        val geisDeliveryName: String,
+        val geisDeliveryOffice: String,
+        val location: String,
+        val reason: String,
+        val receiverName: String,
+        val senderNo: String,
+        val status: String
+    )
+
+    override suspend fun getParcel(trackingId: String, postalCode: String?): Parcel {
+        val resp = try {
+            service.getEvents(apiKey, GetEventsRequest(GetEvents(trackingId)))
+        } catch (_: HttpException) {
+            throw ParcelNonExistentException()
+        }
+
+        if (resp.getEventsResponse.GetEventsResult.isEmpty()) {
+            throw ParcelNonExistentException()
+        }
+
+        val events = resp.getEventsResponse.GetEventsResult.map {
+            ParcelHistoryItem(
+                it.activity,
+                LocalDateTime.parse(it.date, DateTimeFormatter.ISO_DATE_TIME),
+                it.location
+            )
+        }
+
+        val status = mapTraceCode(resp.getEventsResponse.GetEventsResult.first().traceCode)
+
+        return Parcel(trackingId, events, status)
+    }
+
+    // There is a lot of trace codes so I did my best to categorise them
+    private fun mapTraceCode(traceCode: Int): Status {
+        return when (traceCode) {
+            35 -> Status.Preadvice  // "Your item is on its way to us"
+            15 -> Status.InWarehouse  // "Your item has been handed to An Post"
+            48 -> Status.InWarehouse  // "We have your item and will process it for delivery"
+            1 -> Status.InTransit  // "Your delivery has been sorted in"
+            52 -> Status.InTransit  // "Your delivery is in"
+            73 -> Status.InTransit  // "Your item is being prepared for delivery"
+            4 -> Status.OutForDelivery  // "Your item is out for delivery"
+            13 -> Status.DeliveryFailure  // "We tried to deliver your item"
+            14 -> Status.Delivered  // "Your item has been delivered"
+            else -> logUnknownStatus("AnPost", "TraceCode: $traceCode")
+        }
+    }
 }

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -32,6 +32,7 @@ enum class Service {
     SAMEDAY_BG,
     SAMEDAY_HU,
     SAMEDAY_RO,
+    AN_POST,
 
     // Asia
     SPX_TH,
@@ -58,6 +59,7 @@ fun getDeliveryService(service: Service): DeliveryService? {
         Service.SAMEDAY_BG -> SamedayBulgariaDeliveryService
         Service.SAMEDAY_HU -> SamedayHungaryDeliveryService
         Service.SAMEDAY_RO -> SamedayRomaniaDeliveryService
+        Service.AN_POST -> AnPostDeliveryService
 
         Service.SPX_TH -> SPXThailandDeliveryService
 

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -24,6 +24,7 @@ enum class Service {
     EVRI,
 
     // Europe
+    AN_POST,
     BELPOST,
     MAGYAR_POSTA,
     PACKETA,
@@ -32,7 +33,6 @@ enum class Service {
     SAMEDAY_BG,
     SAMEDAY_HU,
     SAMEDAY_RO,
-    AN_POST,
 
     // Asia
     SPX_TH,
@@ -51,6 +51,7 @@ fun getDeliveryService(service: Service): DeliveryService? {
         Service.DPD_UK -> DpdUkDeliveryService
         Service.EVRI -> EvriDeliveryService
 
+        Service.AN_POST -> AnPostDeliveryService
         Service.BELPOST -> BelpostDeliveryService
         Service.MAGYAR_POSTA -> MagyarPostaDeliveryService
         Service.PACKETA -> PacketaDeliveryService
@@ -59,7 +60,6 @@ fun getDeliveryService(service: Service): DeliveryService? {
         Service.SAMEDAY_BG -> SamedayBulgariaDeliveryService
         Service.SAMEDAY_HU -> SamedayHungaryDeliveryService
         Service.SAMEDAY_RO -> SamedayRomaniaDeliveryService
-        Service.AN_POST -> AnPostDeliveryService
 
         Service.SPX_TH -> SPXThailandDeliveryService
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="service_dhl" translatable="false">DHL</string>
     <string name="service_polish_post">Polish Post</string>
     <string name="service_belpost">Belpost</string>
+    <string name="service_an_post">An Post</string>
 
     <string name="add_a_parcel">Add a parcel</string>
     <string name="go_back">Go back</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="service_dhl" translatable="false">DHL</string>
     <string name="service_polish_post">Polish Post</string>
     <string name="service_belpost">Belpost</string>
-    <string name="service_an_post">An Post</string>
+    <string name="service_an_post" translatable="false">An Post</string>
 
     <string name="add_a_parcel">Add a parcel</string>
     <string name="go_back">Go back</string>

--- a/app/src/test/java/dev/itsvic/parceltracker/api/FormatValidationTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/api/FormatValidationTest.kt
@@ -39,7 +39,7 @@ class FormatValidationTest {
     }
 
     @Test fun anPostFormatReturnsTrue() {
-        assertTrue(AnPostDeliveryService.acceptsFormat("AY123456789IE"))
+        assertTrue(AnPostDeliveryService.acceptsFormat("Ay123456789Ie"))
     }
     @Test fun anPostFormatReturnsFalse() {
         assertFalse(AnPostDeliveryService.acceptsFormat("AY12345678HA"))

--- a/app/src/test/java/dev/itsvic/parceltracker/api/FormatValidationTest.kt
+++ b/app/src/test/java/dev/itsvic/parceltracker/api/FormatValidationTest.kt
@@ -1,6 +1,7 @@
 import dev.itsvic.parceltracker.api.MagyarPostaDeliveryService
 import dev.itsvic.parceltracker.api.PacketaDeliveryService
 import dev.itsvic.parceltracker.api.PolishPostDeliveryService
+import dev.itsvic.parceltracker.api.AnPostDeliveryService
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -35,5 +36,12 @@ class FormatValidationTest {
     }
     @Test fun packeta_CanonicalFormatNoSpaces_ReturnsTrue() {
         assertTrue(PacketaDeliveryService.acceptsFormat("Z1234567890"))
+    }
+
+    @Test fun anPostFormatReturnsTrue() {
+        assertTrue(AnPostDeliveryService.acceptsFormat("AY123456789IE"))
+    }
+    @Test fun anPostFormatReturnsFalse() {
+        assertFalse(AnPostDeliveryService.acceptsFormat("AY12345678HA"))
     }
 }

--- a/fastlane/metadata/android/pl-PL/changelogs/10100000.txt
+++ b/fastlane/metadata/android/pl-PL/changelogs/10100000.txt
@@ -1,7 +1,7 @@
-- Archiwizacja paczek jest już dostępna! Możesz archiwizować paczki, aby zachować ich historię na urządzeniu.
-- Usługi dostawcze są teraz sortowane według tego, czy akceptują podany identyfikator śledzenia.
-- Paczki są teraz wyświetlane w kolejności ostatnio dodanej.
+- Archiwizacja paczek jest już dostępna! Możesz archiwizować paczki, aby zachować ich historię lokalnie.
+- Usługi są teraz sortowane według tego, czy akceptują dany identyfikator śledzenia.
+- Paczki są teraz wyświetlane w najnowszej kolejności.
 - Teraz możesz kopiować opisy w historii przesyłki.
-- Naprawiono błąd powodujący, że kod pocztowy nie był zapisywany, gdy był wymagany przez usługę.
+- Naprawiono błąd, gdzie kod pocztowy nie był zapisywany, gdy był wymagany przez usługę.
 - Belpost: Naprawiono pewne skrajne przypadki awarii.
 - UPS: Naprawiono awarie dla nieistniejących paczek.


### PR DESCRIPTION
I've never used Kotlin or even contributed before, but I wanted to add the primary delivery service used in Ireland, An Post, to this app. Let me know if there are any problems. :)

Copilot Summary:

This pull request introduces support for the An Post delivery service. The most important changes include adding the An Post delivery service implementation, updating the service enum and related functions, and adding tests for the new service.

Implementation of An Post delivery service:

* [`app/src/main/java/dev/itsvic/parceltracker/api/AnPostDeliveryService.kt`](diffhunk://#diff-d75f2a6fbf875fd8e4e6c4bb1b650162d77d75c1c49880d7c2ff776b04542129R1-R136): Added a new delivery service implementation for An Post, including methods to fetch parcel events and item summaries, and to map trace codes to statuses.

Updates to service enum and related functions:

* [`app/src/main/java/dev/itsvic/parceltracker/api/Core.kt`](diffhunk://#diff-0bfc45c26074f823bebe3a24447986d58d2dcda366f0ac5657f4ddb38807525fR38): Added `AN_POST` to the `Service` enum and updated the `getDeliveryService` function to return `AnPostDeliveryService` for this new service. [[1]](diffhunk://#diff-0bfc45c26074f823bebe3a24447986d58d2dcda366f0ac5657f4ddb38807525fR38) [[2]](diffhunk://#diff-0bfc45c26074f823bebe3a24447986d58d2dcda366f0ac5657f4ddb38807525fR67)

Updates to resources:

* [`app/src/main/res/values/strings.xml`](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R21): Added a string resource for the An Post service name.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40): Added An Post to the list of supported delivery services under Europe.

Testing:

* [`app/src/test/java/dev/itsvic/parceltracker/api/FormatValidationTest.kt`](diffhunk://#diff-2988676e39c5ed48fc8efe704df9149e3cec4aaeb2c6cbcbb5762d9811804659R4): Added tests for the An Post format validation to ensure it correctly accepts and rejects tracking IDs. [[1]](diffhunk://#diff-2988676e39c5ed48fc8efe704df9149e3cec4aaeb2c6cbcbb5762d9811804659R4) [[2]](diffhunk://#diff-2988676e39c5ed48fc8efe704df9149e3cec4aaeb2c6cbcbb5762d9811804659R40-R46)

![Screenshot_2025-04-06-15-56-36-632_dev itsvic parceltracker](https://github.com/user-attachments/assets/f4f612ad-0635-430f-93e0-334c11faceef)

![Screenshot_2025-04-05-19-52-55-449_dev itsvic parceltracker](https://github.com/user-attachments/assets/36940539-53ff-4bd9-9277-58503f34aab5)

![Screenshot_2025-04-06-15-56-40-589_dev itsvic parceltracker](https://github.com/user-attachments/assets/0a3a7bb5-ef17-40f3-8dd0-f7baca7aee66)
