### PR TITLE
Update Swedish Translations

### DIFF
--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -18,7 +18,7 @@
     <string name="service_polish_post">Polska Posten</string>
     <string name="service_belpost">Belpost</string>
 
-    <string name="add_a_parcel">Lägg till en paket</string>
+    <string name="add_a_parcel">Lägg till ett paket</string>
     <string name="go_back">Tillbaka</string>
     <string name="parcel_name">Namn</string>
     <string name="tracking_id">Spårningsnummer</string> <!-- eller Spårnings-ID? -->
@@ -26,7 +26,7 @@
     <string name="specify_a_postal_code">Ange postnummer</string>
     <string name="postal_code">Postnummer</string>
     <string name="add_parcel">Lägg till paketet</string>
-    <string name="specify_postal_code_flavor_text">Valfritt. Du kan kanske få tillgång till extra information, såsom läge, med en postnummer.</string>
+    <string name="specify_postal_code_flavor_text">Valfritt. Du kan kanske få tillgång till extra information, såsom läge, med ett postnummer.</string>
 
     <string name="no_parcels_flavor">Du har för närvarande inga paket.</string>
 
@@ -40,20 +40,20 @@
     <string name="network_failure_detail">Din enhet kan vara offline, servicens servrar kan vara offline eller de uppgifter du har angett kan vara felaktiga.</string>
     <string name="settings">Inställningar</string>
     <string name="demo_mode_detail">Visar exempelpaket för demoändamål. Påverkar inte användardata.</string>
-    <string name="parcel_doesnt_exist_detail">Den paket finns inte på leveransservicens servrar än. Se till att paketdetaljer är korrekt.</string>
+    <string name="parcel_doesnt_exist_detail">Det paketet finns inte på leveransservicens servrar än. Se till att paketdetaljerna är korrekt.</string>
     <string name="more_options">Fler alternativ</string>
     <string name="delete">Ta bort</string>
     <string name="demo_mode">Demo-läge</string>
     <string name="demo_mode_action_block">Åtgärd inte tillåten i demo-läge</string>
-    <string name="settings_experimental">Eksperimentell</string>
+    <string name="settings_experimental">Experimentell</string>
     <string name="status_no_data">Ingen data</string>
     <string name="channel_name">Pakethändelser</string>
     <string name="channel_description">Meddelanden om paketets nuvarande status</string>
     <string name="unmetered_only_setting">Uppdatera endast på obegränsade nätverk</string>
     <string name="unmetered_only_setting_detail">Om aktiverat söker Parcel efter uppdateringar endast via obegränsade anslutningar, t.ex. ditt hem-Wi-Fi.</string>
-    <string name="edit_parcel">Regidera paket</string>
+    <string name="edit_parcel">Redigera paket</string>
     <string name="save">Spara</string>
-    <string name="edit">Regidera</string>
+    <string name="edit">Redigera</string>
     <string name="service_dpd_uk">DPD UK</string>
     <string name="service_sameday_hu">Sameday Ungern</string>
     <string name="service_sameday_ro">Sameday Rumänien</string>
@@ -71,10 +71,10 @@
     <string name="service_hungarian_post">Ungerska Posten</string> <!-- TODO: deras webbplats på engelska säger fortfarande "Magyar Posta" så jag valde endonymen? (: -->
     <string name="archive">Arkivera</string>
     <string name="archive_prompt_question">Vill du arkivera den här paket?</string>
-    <string name="archive_prompt_text">Om du arkivera den här paket, kommer dess historia att sparas på enheten. Det kommer inte att kontrolleras för uppdateringar.</string>
+    <string name="archive_prompt_text">Om du arkiverar det här paketet, kommer dess historia att sparas på enheten. Det kommer inte att kontrolleras för uppdateringar.</string>
     <string name="ignore">Tysta</string>
     <string name="service_nova_poshta">Nova Post</string> <!-- some part of their website in english also says "New Post"... just English loanwords as per usual should be fine -->
-    <string name="error_no_api_key_provided">Denna leveransservice kräver en API-nyckel men ingen angavs. Kontrollera appens inställningar for mer information.</string> <!-- staying on "but none were provided" instead of "but one wasn't provided" -->
+    <string name="error_no_api_key_provided">Denna leveransservice kräver en API-nyckel men ingen angavs. Kontrollera appens inställningar för mer information.</string> <!-- staying on "but none were provided" instead of "but one wasn't provided" -->
     <string name="dhl_api_key_flavor_text"><![CDATA[DHL kräver att vi ber användarna att ange en API-nyckel. Du kan få en gratis från <a href=\"https://developer.dhl.com\">DHL:s API Developer Portal</a> genom att registera dig för \"Shipment Tracking - Unified\" API.]]></string>
     <string name="settings_api_keys">API-nycklar</string>
     <string name="service_ukrposhta">Ukrposhta</string> <!-- the official English translation is just a romanization so I will preserve that -->


### PR DESCRIPTION
Fixed some weird grammar in the Swedish translation and some typos.

Kinda feel like the translation for unmetered_only_setting should be changed to something like "omättade nätverk" or similar.

Especially since the word "unmetered" is talking about the network being monitored for data usage or not. While _obegränsade_ doesn't fully mean the same thing. I would also say "Uppdatera endast via Wi-Fi" would maybe fit better. But then it would say something more like "Only update over Wi-Fi"