### PR TITLE
WIP: Add Smartspacer support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation(libs.work.runtime.ktx)
     implementation(libs.kotlinx.coroutines.guava)
     implementation(libs.androidx.browser)
+    implementation(libs.smartspacer)
 
     ksp(libs.room.compiler)
     ksp(libs.moshi.kotlin.codegen)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-sdk tools:overrideLibrary="com.kieronquinn.app.smartspacer.sdk, com.kieronquinn.app.smartspacer.sdk.plugin" />
+
     <application
         android:name=".ParcelApplication"
         android:allowBackup="true"
@@ -27,5 +29,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name=".smartspacer.targets.ParcelStatusTarget"
+            android:authorities="${applicationId}.target.example"
+            android:permission="com.kieronquinn.app.smartspacer.permission.ACCESS_SMARTSPACER_TARGETS"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.kieronquinn.app.smartspacer.TARGET" />
+            </intent-filter>
+        </provider>
     </application>
 </manifest>

--- a/app/src/main/java/dev/itsvic/parceltracker/NotificationWorker.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/NotificationWorker.kt
@@ -11,8 +11,10 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.kieronquinn.app.smartspacer.sdk.provider.SmartspacerTargetProvider
 import dev.itsvic.parceltracker.api.getParcel
 import dev.itsvic.parceltracker.db.ParcelStatus
+import dev.itsvic.parceltracker.smartspacer.targets.ParcelStatusTarget
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -79,6 +81,9 @@ class NotificationWorker(context: Context, params: WorkerParameters) :
                 }
             }
         }
+
+        // TODO: this most likely has to be moved
+        SmartspacerTargetProvider.notifyChange(applicationContext, ParcelStatusTarget::class.java)
 
         return Result.success()
     }

--- a/app/src/main/java/dev/itsvic/parceltracker/smartspacer/targets/ParcelStatusTarget.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/smartspacer/targets/ParcelStatusTarget.kt
@@ -1,0 +1,105 @@
+package dev.itsvic.parceltracker.smartspacer.targets
+
+import android.content.ComponentName
+import android.util.Log
+import android.graphics.drawable.Icon as AndroidIcon
+import com.kieronquinn.app.smartspacer.sdk.model.SmartspaceTarget
+import com.kieronquinn.app.smartspacer.sdk.model.uitemplatedata.Icon
+import com.kieronquinn.app.smartspacer.sdk.model.uitemplatedata.Text
+import com.kieronquinn.app.smartspacer.sdk.provider.SmartspacerTargetProvider
+import com.kieronquinn.app.smartspacer.sdk.utils.TargetTemplate
+import dev.itsvic.parceltracker.ParcelApplication
+import dev.itsvic.parceltracker.R
+import dev.itsvic.parceltracker.api.Status
+import dev.itsvic.parceltracker.api.getParcel
+import dev.itsvic.parceltracker.db.ParcelWithStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlin.String
+
+class ParcelStatusTarget: SmartspacerTargetProvider() {
+    override fun getSmartspaceTargets(smartspacerId: String): List<SmartspaceTarget> {
+        val targets = mutableListOf<SmartspaceTarget>()
+
+        val db = ParcelApplication.db
+        val parcels: List<ParcelWithStatus> = runBlocking(Dispatchers.IO) {
+            db.parcelDao().getAllNonArchivedWithStatusAsync()
+        }
+
+        // this doesn't limit the number of returned targets
+        // it probably should, but I don't know whether to hardcode it or make configurable
+
+        parcels.forEach { parcelWithStatus ->
+            val parcel = parcelWithStatus.parcel
+
+            val apiParcel = try {
+                runBlocking(Dispatchers.IO) {
+                    provideContext().getParcel(parcel.parcelId, parcel.postalCode, parcel.service)
+                }
+            } catch (e: Exception) {
+                Log.d(TAG, "Failed to fetch, skipping", e)
+
+                return@forEach
+            }
+
+            // TODO: is the one from API or db preferred
+            val status = apiParcel.currentStatus //parcelWithStatus.status?.status
+
+            targets.add(
+                TargetTemplate.Basic(
+                    id = "parcel_status_$smartspacerId",
+                    componentName = ComponentName(
+                        provideContext(),
+                        ParcelStatusTarget::class.java
+                    ),
+//                    featureType = SmartspaceTarget.FEATURE_PACKAGE_TRACKING,
+                    title = Text("${parcel.humanName}: ${status.name}"),
+                    subtitle = Text(apiParcel.history.first().description),
+                    icon = Icon(
+                        AndroidIcon.createWithResource(
+                            provideContext(),
+                            // this when is the same as the one in ParcelRow, maybe unify those two?
+                            when (status) {
+                                Status.Preadvice -> R.drawable.outline_other_admission_24
+                                Status.InTransit -> R.drawable.outline_local_shipping_24
+                                Status.InWarehouse -> R.drawable.outline_warehouse_24
+                                Status.Customs -> R.drawable.outline_search_24
+                                Status.OutForDelivery -> R.drawable.outline_local_shipping_24
+                                Status.DeliveryFailure -> R.drawable.outline_error_24
+                                Status.AwaitingPickup -> R.drawable.outline_pin_drop_24
+                                Status.Delivered, Status.PickedUp -> R.drawable.outline_check_24
+
+                                else -> R.drawable.outline_question_mark_24
+                            }
+                        )
+                    ),
+                    onClick = null     // TODO: change
+                ).create().apply {
+                    isSensitive = true
+                    canBeDismissed = false
+                })
+        }
+
+        return targets
+    }
+
+    override fun getConfig(smartspacerId: String?): Config {
+        return Config(
+            label = "Parcel Status",
+            description = "Shows the current status of a selected parcel",
+            icon = AndroidIcon.createWithResource(provideContext(), R.drawable.package_2),
+            allowAddingMoreThanOnce = true,
+//            configActivity = // Optional: An Intent given as an option to the user in the settings UI after adding
+//            setupActivity = // Optional: An Intent of an Activity presented to the user during setup (see below)
+        )
+    }
+
+    override fun onDismiss(smartspacerId: String, targetId: String): Boolean {
+        return false
+    }
+
+    companion object {
+        private const val TAG = "ParcelStatusTarget"
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ work = "2.10.0"
 kotlinxCoroutinesGuava = "1.10.1"
 material3 = "1.4.0-alpha11"
 browser = "1.8.0"
+smartspacer = "1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -57,6 +58,7 @@ work-runtime = { group = "androidx.work", name = "work-runtime", version.ref = "
 work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version.ref = "kotlinxCoroutinesGuava" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
+smartspacer = { group = "com.kieronquinn.smartspacer", name = "sdk-plugin", version.ref = "smartspacer" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Hi,
This PR adds support for [Smartspacer](https://github.com/KieronQuinn/Smartspacer/) so that parcels can be displayed in the At a Glance. I've mostly made this for myself, but seeing that it's not that much code, maybe someone else might benefit from it too.

There's more work on my part for this to be ready, but I wanted to ask a couple of questions:
- is this something you're interested in?

- is there any one place that triggers updates of the db? for now I'm using notification worker (which... is not good), but maybe I've missed something
- how's status from the API different from the one stored in DB? (and which one should be preferred?)

Screenshots:
|                                                          Parcel                                                          |                                         AfterShip (which I used as a reference)                                          |
|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot_20250422-153428_Lawnchair](https://github.com/user-attachments/assets/b0a8d8d0-cdec-40e3-b7d6-a92c208073fa) | ![Screenshot_20250422-153430_Lawnchair](https://github.com/user-attachments/assets/8987d747-4efb-4312-978c-78bfce228e9b) |


Also thanks for this awesome project! Looking forward to all the future development.