### PR TITLE
Fix: Handle missing location data in PostNord API

### DIFF
--- a/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/PostNordDeliveryService.kt
@@ -3,6 +3,7 @@ package dev.itsvic.parceltracker.api
 import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
+import java.io.IOException
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import retrofit2.HttpException
@@ -23,52 +24,52 @@ object PostNordDeliveryService : DeliveryService {
   private const val DEFAULT_LOCALE = "en"
   private val supportedLocales = setOf("en", "sv", "no", "da", "fi")
 
-  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+  private fun getApiLocale(): String {
     val locale = LocaleList.getDefault().get(0).language
-    val apiLocale =
-        if (supportedLocales.contains(locale)) {
-          locale
-        } else {
-          DEFAULT_LOCALE
-        }
+    return if (supportedLocales.contains(locale)) locale else DEFAULT_LOCALE
+  }
 
-    val resp =
-        try {
-          service.getShipments(trackingId, apiLocale)
-        } catch (_: HttpException) {
-          throw ParcelNonExistentException()
-        }
+  private val statusMapping = mapOf(
+    "CREATED" to Status.Preadvice,
+    "EN_ROUTE" to Status.InTransit,
+    "DELAYED" to Status.InTransit,
+    "EXPECTED_DELAY" to Status.InTransit,
+    "AVAILABLE_FOR_DELIVERY" to Status.InWarehouse,
+    "AVAILABLE_FOR_DELIVERY_PAR_LOC" to Status.InWarehouse,
+    "DELIVERED" to Status.Delivered,
+    "DELIVERY_IMPOSSIBLE" to Status.DeliveryFailure,
+    "DELIVERY_REFUSED" to Status.DeliveryFailure,
+    "STOPPED" to Status.DeliveryFailure,
+    "RETURNED" to Status.DeliveryFailure,
+    "OTHER" to Status.Unknown,
+    "INFORMED" to Status.Unknown
+  )
 
-    val item = resp.items.first()
+  override suspend fun getParcel(trackingId: String, postCode: String?): Parcel {
+    val resp = try {
+      service.getShipments(trackingId, getApiLocale())
+    } catch (e: HttpException) {
+      when (e.code()) {
+        404 -> throw ParcelNonExistentException()
+        else -> throw IOException("Failed to fetch parcel information: ${e.message()}")
+      }
+    }
 
-    val status =
-        when (item.status.code) {
-          "CREATED" -> Status.Preadvice
-          "EN_ROUTE",
-          "DELAYED",
-          "EXPECTED_DELAY" -> Status.InTransit
-          "AVAILABLE_FOR_DELIVERY",
-          "AVAILABLE_FOR_DELIVERY_PAR_LOC" -> Status.InWarehouse
-          "DELIVERED" -> Status.Delivered
-          "DELIVERY_IMPOSSIBLE",
-          "DELIVERY_REFUSED",
-          "STOPPED",
-          "RETURNED" -> Status.DeliveryFailure
-          "OTHER",
-          "INFORMED" -> Status.Unknown
-          else -> logUnknownStatus("PostNord", item.status.code)
-        }
+    val item = resp.items.firstOrNull() ?: throw ParcelNonExistentException()
 
-    val history =
-        item.events.map {
-          ParcelHistoryItem(
-              it.eventDescription,
-              ZonedDateTime.parse(it.eventTime)
-                  .withZoneSameInstant(ZoneId.systemDefault())
-                  .toLocalDateTime(),
-              if (it.location.name != null) "${it.location.name}, ${it.location.countryCode}"
-              else it.location.countryCode)
-        }
+    val status = statusMapping[item.status.code] ?: logUnknownStatus("PostNord", item.status.code)
+
+    val history = item.events.map {
+      ParcelHistoryItem(
+        it.eventDescription,
+        ZonedDateTime.parse(it.eventTime)
+          .withZoneSameInstant(ZoneId.systemDefault())
+          .toLocalDateTime(),
+        listOfNotNull(
+          it.location.name,
+          it.location.countryCode
+        ).joinToString(", "))
+    }
 
     return Parcel(resp.shipmentId, history, status)
   }
@@ -118,9 +119,9 @@ object PostNordDeliveryService : DeliveryService {
 
   @JsonClass(generateAdapter = true)
   internal data class Location(
-      val countryCode: String,
-      val locationType: String,
-      val name: String?
+    val countryCode: String?,
+    val locationType: String?,
+    val name: String?
   )
 
   @JsonClass(generateAdapter = true)


### PR DESCRIPTION
When I tried tracking some new packages I got one that wouldn't track.

Checked the logs and turns out some of the location data is sometimes not there, so they needed to be nullable. Also changed how the status was mapped and how the string for the location was constructed to make it easier to add / remove any future parts of it.