### PR TITLE
Add support for tracking parcels shipped with Cainiao

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Similarly, we have `./scripts/sort-strings.sh` to sort translation files by key.
 ## Supported services
 
 International:
+- Cainiao
 - DHL
 - GLS
 - UPS

--- a/app/src/main/java/dev/itsvic/parceltracker/api/CainiaoDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/CainiaoDeliveryService.kt
@@ -1,0 +1,107 @@
+package dev.itsvic.parceltracker.api
+
+import com.squareup.moshi.JsonClass
+import dev.itsvic.parceltracker.R
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Locale
+
+object CainiaoDeliveryService : DeliveryService {
+  override val nameResource: Int = R.string.service_cainiao
+  override val acceptsPostCode: Boolean = false
+  override val requiresPostCode: Boolean = false
+
+  override suspend fun getParcel(trackingID: String, postalCode: String?): Parcel {
+    var userLocale = Locale.getDefault()
+    var language = userLocale.language
+    val country = userLocale.country
+
+    val parcelResp = service.getParcel(trackingID, "$language-$country", "$language-$country")
+
+    if (!parcelResp.success || parcelResp.module.isEmpty() || parcelResp.module.first().detailList.isEmpty()) {
+      throw ParcelNonExistentException()
+    }
+
+    val parcel = parcelResp.module.first()
+
+    val history =
+        parcel.detailList.map {
+          ParcelHistoryItem(
+              it.standerdDesc,
+              // Sometimes new parcels have no timezone info, so default to origin country (china)
+              LocalDateTime.ofInstant(Instant.ofEpochMilli(it.time), ZoneId.of(if (it.timeZone.isBlank()) "GMT+8" else it.timeZone)),
+              ""
+          )
+        }
+
+    // Based on the few tracking numbers I have, there may be more
+    val status =
+        when (parcel.detailList.first().actionCode) {
+          "GWMS_ACCEPT" -> Status.Preadvice
+          "GWMS_PACKAGE" -> Status.AwaitingPickup
+          "GWMS_OUTBOUND" -> Status.InTransit
+          "PU_PICKUP_SUCCESS" -> Status.PickedUp
+          "CW_OUTBOUND" -> Status.InTransit
+          "SC_INBOUND_SUCCESS" -> Status.InWarehouse
+          "SC_OUTBOUND_SUCCESS" -> Status.InTransit
+          "LH_HO_IN_SUCCESS" -> Status.InWarehouse
+          "LH_HO_AIRLINE" -> Status.InTransit
+          "LH_DEPART" -> Status.InTransit
+          "LH_ARRIVE" -> Status.InWarehouse
+          "CC_EX_START" -> Status.Customs
+          "CC_EX_SUCCESS" -> Status.CustomsSuccess
+          "CC_HO_IN_SUCCESS" -> Status.Customs
+          "CC_HO_OUT_SUCCESS" -> Status.InTransit
+          "CC_IM_START" -> Status.Customs
+          "CC_IM_SUCCESS" -> Status.CustomsSuccess
+          "GTMS_ACCEPT" -> Status.InTransit
+          "GTMS_DO_ARRIVE" -> Status.InWarehouse
+          "GTMS_DO_DEPART" -> Status.OutForDelivery
+          "GTMS_STATION_OUT" -> Status.InTransit
+          "GTMS_SIGNED" -> Status.Delivered
+          else ->
+              logUnknownStatus(
+                  "Cainiao", parcel.detailList.first().actionCode)
+        }
+
+    return Parcel(trackingID, history, status)
+  }
+
+  private val retrofit =
+      Retrofit.Builder()
+          .baseUrl("https://global.cainiao.com/global/")
+          .client(api_client)
+          .addConverterFactory(MoshiConverterFactory.create(api_moshi))
+          .build()
+
+  private val service = retrofit.create(API::class.java)
+
+  private interface API {
+    @GET("detail.json")
+    suspend fun getParcel(@Query("mailNos") trackingID: String, @Query("lang") lang: String, @Query("language") language: String): ParcelResponse
+  }
+
+  @JsonClass(generateAdapter = true)
+  internal data class ParcelResponse(
+      val module: List<CainiaoParcel>,
+      val success: Boolean,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class CainiaoParcel(
+      val detailList: List<Event>,
+  )
+
+  @JsonClass(generateAdapter = true)
+  internal data class Event(
+      val actionCode: String,
+      val standerdDesc: String,
+      val time: Long,
+      val timeZone: String,
+  )
+}

--- a/app/src/main/java/dev/itsvic/parceltracker/api/CainiaoDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/CainiaoDeliveryService.kt
@@ -62,11 +62,13 @@ object CainiaoDeliveryService : DeliveryService {
           "CC_HO_OUT_SUCCESS" -> Status.InTransit
           "CC_IM_START" -> Status.Customs
           "CC_IM_SUCCESS" -> Status.CustomsSuccess
+          "TD_TRANSWH_OUTBOUND" -> Status.InTransit
           "GTMS_ACCEPT" -> Status.InTransit
           "GTMS_DO_ARRIVE" -> Status.InWarehouse
           "GTMS_DO_DEPART" -> Status.OutForDelivery
           "GTMS_STATION_OUT" -> Status.InTransit
           "GTMS_SIGNED" -> Status.Delivered
+          "GTMS_DEL_FAILURE" -> Status.DeliveryFailure
           else -> logUnknownStatus("Cainiao", parcel.detailList.first().actionCode)
         }
 

--- a/app/src/main/java/dev/itsvic/parceltracker/api/CainiaoDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/CainiaoDeliveryService.kt
@@ -2,14 +2,14 @@ package dev.itsvic.parceltracker.api
 
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
-import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
-import retrofit2.http.GET
-import retrofit2.http.Query
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Locale
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
 
 object CainiaoDeliveryService : DeliveryService {
   override val nameResource: Int = R.string.service_cainiao
@@ -23,7 +23,9 @@ object CainiaoDeliveryService : DeliveryService {
 
     val parcelResp = service.getParcel(trackingID, "$language-$country", "$language-$country")
 
-    if (!parcelResp.success || parcelResp.module.isEmpty() || parcelResp.module.first().detailList.isEmpty()) {
+    if (!parcelResp.success ||
+        parcelResp.module.isEmpty() ||
+        parcelResp.module.first().detailList.isEmpty()) {
       throw ParcelNonExistentException()
     }
 
@@ -34,9 +36,10 @@ object CainiaoDeliveryService : DeliveryService {
           ParcelHistoryItem(
               it.standerdDesc,
               // Sometimes new parcels have no timezone info, so default to origin country (china)
-              LocalDateTime.ofInstant(Instant.ofEpochMilli(it.time), ZoneId.of(if (it.timeZone.isBlank()) "GMT+8" else it.timeZone)),
-              ""
-          )
+              LocalDateTime.ofInstant(
+                  Instant.ofEpochMilli(it.time),
+                  ZoneId.of(if (it.timeZone.isBlank()) "GMT+8" else it.timeZone)),
+              "")
         }
 
     // Based on the few tracking numbers I have, there may be more
@@ -64,9 +67,7 @@ object CainiaoDeliveryService : DeliveryService {
           "GTMS_DO_DEPART" -> Status.OutForDelivery
           "GTMS_STATION_OUT" -> Status.InTransit
           "GTMS_SIGNED" -> Status.Delivered
-          else ->
-              logUnknownStatus(
-                  "Cainiao", parcel.detailList.first().actionCode)
+          else -> logUnknownStatus("Cainiao", parcel.detailList.first().actionCode)
         }
 
     return Parcel(trackingID, history, status)
@@ -83,7 +84,11 @@ object CainiaoDeliveryService : DeliveryService {
 
   private interface API {
     @GET("detail.json")
-    suspend fun getParcel(@Query("mailNos") trackingID: String, @Query("lang") lang: String, @Query("language") language: String): ParcelResponse
+    suspend fun getParcel(
+        @Query("mailNos") trackingID: String,
+        @Query("lang") lang: String,
+        @Query("language") language: String
+    ): ParcelResponse
   }
 
   @JsonClass(generateAdapter = true)

--- a/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/Core.kt
@@ -19,6 +19,7 @@ enum class Service {
   EXAMPLE,
 
   // International
+  CAINIAO,
   DHL,
   GLS,
   UPS,
@@ -60,6 +61,7 @@ val serviceOptions =
 
 fun getDeliveryService(service: Service): DeliveryService? {
   return when (service) {
+    Service.CAINIAO -> CainiaoDeliveryService
     Service.DHL -> DhlDeliveryService
     Service.GLS -> GLSGlobalDeliveryService
     Service.UPS -> UPSDeliveryService
@@ -123,6 +125,7 @@ enum class Status(val nameResource: Int) {
   InTransit(R.string.status_in_transit),
   InWarehouse(R.string.status_in_warehouse),
   Customs(R.string.status_customs),
+  CustomsSuccess(R.string.status_customs_cleared),
   OutForDelivery(R.string.status_out_for_delivery),
   DeliveryFailure(R.string.status_delivery_failure),
   Delivered(R.string.status_delivered),

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -51,8 +51,8 @@
   <string name="specify_postal_code_flavor_text">Volitelné. S poštovním směrovacím číslem můžete získat přístup k více informacím, jako je poloha.</string>
   <string name="status_awaiting_pickup">Čeká na vyzvednutí</string>
   <string name="status_customs">Dorazilo na celnici</string>
-    <string name="status_customs_cleared">Celní odbavení</string>
-    <string name="status_delivered">Doručeno</string>
+  <string name="status_customs_cleared">Celní odbavení</string>
+  <string name="status_delivered">Doručeno</string>
   <string name="status_delivery_failure">Nepodařilo se doručit</string>
   <string name="status_in_transit">Na cestě</string>
   <string name="status_in_warehouse">Dorazilo na depo</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -51,7 +51,8 @@
   <string name="specify_postal_code_flavor_text">Volitelné. S poštovním směrovacím číslem můžete získat přístup k více informacím, jako je poloha.</string>
   <string name="status_awaiting_pickup">Čeká na vyzvednutí</string>
   <string name="status_customs">Dorazilo na celnici</string>
-  <string name="status_delivered">Doručeno</string>
+    <string name="status_customs_cleared">Celní odbavení</string>
+    <string name="status_delivered">Doručeno</string>
   <string name="status_delivery_failure">Nepodařilo se doručit</string>
   <string name="status_in_transit">Na cestě</string>
   <string name="status_in_warehouse">Dorazilo na depo</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,8 +58,8 @@
   <string name="specify_postal_code_flavor_text">Optional. Mit einer Postleitzahl könnten zusätzliche Informationen wie Standort angezeigt werden.</string>
   <string name="status_awaiting_pickup">Abholung ausstehend</string>
   <string name="status_customs">Beim Zoll eingetroffen</string>
-    <string name="status_customs_cleared">Vom Zoll abgefertigt</string>
-    <string name="status_delivered">Zugestellt</string>
+  <string name="status_customs_cleared">Vom Zoll abgefertigt</string>
+  <string name="status_delivered">Zugestellt</string>
   <string name="status_delivery_failure">Zustellung fehlgeschlagen</string>
   <string name="status_in_transit">Unterwegs</string>
   <string name="status_in_warehouse">Im Paketzentrum eingetroffen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,7 +58,8 @@
   <string name="specify_postal_code_flavor_text">Optional. Mit einer Postleitzahl könnten zusätzliche Informationen wie Standort angezeigt werden.</string>
   <string name="status_awaiting_pickup">Abholung ausstehend</string>
   <string name="status_customs">Beim Zoll eingetroffen</string>
-  <string name="status_delivered">Zugestellt</string>
+    <string name="status_customs_cleared">Vom Zoll abgefertigt</string>
+    <string name="status_delivered">Zugestellt</string>
   <string name="status_delivery_failure">Zustellung fehlgeschlagen</string>
   <string name="status_in_transit">Unterwegs</string>
   <string name="status_in_warehouse">Im Paketzentrum eingetroffen</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -52,8 +52,8 @@
   <string name="specify_postal_code_flavor_text">Opcionális. További információ jelenhet meg az irányítószám megadásával, például a címzett címe.</string>
   <string name="status_awaiting_pickup">Átvételre vár</string>
   <string name="status_customs">Vámkezelés alatt</string>
-    <string name="status_customs_cleared">Vámkezelés befejezve</string>
-    <string name="status_delivered">Kiszállítva</string>
+  <string name="status_customs_cleared">Vámkezelés befejezve</string>
+  <string name="status_delivered">Kiszállítva</string>
   <string name="status_delivery_failure">Sikertelen kiszállítás</string>
   <string name="status_in_transit">Úton</string>
   <string name="status_in_warehouse">Megérkezett a depóba</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -52,7 +52,8 @@
   <string name="specify_postal_code_flavor_text">Opcionális. További információ jelenhet meg az irányítószám megadásával, például a címzett címe.</string>
   <string name="status_awaiting_pickup">Átvételre vár</string>
   <string name="status_customs">Vámkezelés alatt</string>
-  <string name="status_delivered">Kiszállítva</string>
+    <string name="status_customs_cleared">Vámkezelés befejezve</string>
+    <string name="status_delivered">Kiszállítva</string>
   <string name="status_delivery_failure">Sikertelen kiszállítás</string>
   <string name="status_in_transit">Úton</string>
   <string name="status_in_warehouse">Megérkezett a depóba</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,8 +58,8 @@
   <string name="specify_postal_code_flavor_text">任意の設定です。郵便番号を入力すると、場所などの追加情報にアクセスできる場合があります。</string>
   <string name="status_awaiting_pickup">ピックアップ待ち</string>
   <string name="status_customs">税関に到着</string>
-    <string name="status_customs_cleared">通関済み</string>
-    <string name="status_delivered">配達済み</string>
+  <string name="status_customs_cleared">通関済み</string>
+  <string name="status_delivered">配達済み</string>
   <string name="status_delivery_failure">配達に失敗</string>
   <string name="status_in_transit">輸送中</string>
   <string name="status_in_warehouse">倉庫に到着</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,7 +58,8 @@
   <string name="specify_postal_code_flavor_text">任意の設定です。郵便番号を入力すると、場所などの追加情報にアクセスできる場合があります。</string>
   <string name="status_awaiting_pickup">ピックアップ待ち</string>
   <string name="status_customs">税関に到着</string>
-  <string name="status_delivered">配達済み</string>
+    <string name="status_customs_cleared">通関済み</string>
+    <string name="status_delivered">配達済み</string>
   <string name="status_delivery_failure">配達に失敗</string>
   <string name="status_in_transit">輸送中</string>
   <string name="status_in_warehouse">倉庫に到着</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -58,8 +58,8 @@
   <string name="specify_postal_code_flavor_text">Opcjonalne. Możesz uzyskać dostęp do dodatkowych informacji, takich jak lokalizacja, z kodem pocztowym.</string>
   <string name="status_awaiting_pickup">Oczekiwanie na odbiór</string>
   <string name="status_customs">Dotarła do odprawy celnej</string>
-    <string name="status_customs_cleared">Odprawa celna zakończona</string>
-    <string name="status_delivered">Dostarczona</string>
+  <string name="status_customs_cleared">Odprawa celna zakończona</string>
+  <string name="status_delivered">Dostarczona</string>
   <string name="status_delivery_failure">Nie udało się dostarczyć</string>
   <string name="status_in_transit">W tranzycie</string>
   <string name="status_in_warehouse">Dotarła do magazynu</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -58,7 +58,8 @@
   <string name="specify_postal_code_flavor_text">Opcjonalne. Możesz uzyskać dostęp do dodatkowych informacji, takich jak lokalizacja, z kodem pocztowym.</string>
   <string name="status_awaiting_pickup">Oczekiwanie na odbiór</string>
   <string name="status_customs">Dotarła do odprawy celnej</string>
-  <string name="status_delivered">Dostarczona</string>
+    <string name="status_customs_cleared">Odprawa celna zakończona</string>
+    <string name="status_delivered">Dostarczona</string>
   <string name="status_delivery_failure">Nie udało się dostarczyć</string>
   <string name="status_in_transit">W tranzycie</string>
   <string name="status_in_warehouse">Dotarła do magazynu</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -57,8 +57,8 @@
   <string name="specify_postal_code_flavor_text">Valfritt. Du kan kanske få tillgång till extra information, såsom läge, med ett postnummer.</string>
   <string name="status_awaiting_pickup">Väntar på upphämtning</string>
   <string name="status_customs">Anlänt till tullen</string>
-    <string name="status_customs_cleared">Tullklarering slutförd</string>
-    <string name="status_delivered">Levererat</string>
+  <string name="status_customs_cleared">Tullklarering slutförd</string>
+  <string name="status_delivered">Levererat</string>
   <string name="status_delivery_failure">Leveransen misslyckades</string>
   <string name="status_in_transit">I transitering</string>
   <string name="status_in_warehouse">Anlänt till lagret</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -57,7 +57,8 @@
   <string name="specify_postal_code_flavor_text">Valfritt. Du kan kanske få tillgång till extra information, såsom läge, med ett postnummer.</string>
   <string name="status_awaiting_pickup">Väntar på upphämtning</string>
   <string name="status_customs">Anlänt till tullen</string>
-  <string name="status_delivered">Levererat</string>
+    <string name="status_customs_cleared">Tullklarering slutförd</string>
+    <string name="status_delivered">Levererat</string>
   <string name="status_delivery_failure">Leveransen misslyckades</string>
   <string name="status_in_transit">I transitering</string>
   <string name="status_in_warehouse">Anlänt till lagret</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -47,7 +47,8 @@
   <string name="specify_postal_code_flavor_text">เลือกที่จะไม่ใส่ได้ แต่คุณอาจจะเห็นข้อมูลเพิ่มเติม เช่น ตำแหน่ง เมื่อคุณระบุรหัสไปรษณีย์</string>
   <string name="status_awaiting_pickup">กำลังรอบริษัทขนส่งรับพัสดุ</string>
   <string name="status_customs">พัสดุถึงศุลกากร</string>
-  <string name="status_delivered">การนำส่งพัสดุสำเร็จ</string>
+    <string name="status_customs_cleared">ผ่านพิธีการศุลกากรแล้ว</string>
+    <string name="status_delivered">การนำส่งพัสดุสำเร็จ</string>
   <string name="status_delivery_failure">การนำส่งพัสดุล้มเหลว</string>
   <string name="status_in_transit">พัสดุอยู่ระหว่างการขนส่ง</string>
   <string name="status_in_warehouse">พัสดุถึงคลังสินค้า</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -47,8 +47,8 @@
   <string name="specify_postal_code_flavor_text">เลือกที่จะไม่ใส่ได้ แต่คุณอาจจะเห็นข้อมูลเพิ่มเติม เช่น ตำแหน่ง เมื่อคุณระบุรหัสไปรษณีย์</string>
   <string name="status_awaiting_pickup">กำลังรอบริษัทขนส่งรับพัสดุ</string>
   <string name="status_customs">พัสดุถึงศุลกากร</string>
-    <string name="status_customs_cleared">ผ่านพิธีการศุลกากรแล้ว</string>
-    <string name="status_delivered">การนำส่งพัสดุสำเร็จ</string>
+  <string name="status_customs_cleared">ผ่านพิธีการศุลกากรแล้ว</string>
+  <string name="status_delivered">การนำส่งพัสดุสำเร็จ</string>
   <string name="status_delivery_failure">การนำส่งพัสดุล้มเหลว</string>
   <string name="status_in_transit">พัสดุอยู่ระหว่างการขนส่ง</string>
   <string name="status_in_warehouse">พัสดุถึงคลังสินค้า</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -56,7 +56,8 @@
   <string name="specify_postal_code_flavor_text">İsteğe bağlı. Posta kodu ile konum gibi ek bilgilere erişebilirsiniz.</string>
   <string name="status_awaiting_pickup">Teslim alınmayı bekliyor</string>
   <string name="status_customs">Gümrüğe ulaştı</string>
-  <string name="status_delivered">Teslim edildi</string>
+    <string name="status_customs_cleared">Gümrükten geçti</string>
+    <string name="status_delivered">Teslim edildi</string>
   <string name="status_delivery_failure">Teslim edilemedi</string>
   <string name="status_in_transit">Yolda</string>
   <string name="status_in_warehouse">Depoya ulaştı</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -56,8 +56,8 @@
   <string name="specify_postal_code_flavor_text">İsteğe bağlı. Posta kodu ile konum gibi ek bilgilere erişebilirsiniz.</string>
   <string name="status_awaiting_pickup">Teslim alınmayı bekliyor</string>
   <string name="status_customs">Gümrüğe ulaştı</string>
-    <string name="status_customs_cleared">Gümrükten geçti</string>
-    <string name="status_delivered">Teslim edildi</string>
+  <string name="status_customs_cleared">Gümrükten geçti</string>
+  <string name="status_delivered">Teslim edildi</string>
   <string name="status_delivery_failure">Teslim edilemedi</string>
   <string name="status_in_transit">Yolda</string>
   <string name="status_in_warehouse">Depoya ulaştı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -56,8 +56,8 @@
   <string name="specify_postal_code_flavor_text">Додатково. Ми мложете отримати більше інформації, таку як розташування, за допомогою поштового індексу.</string>
   <string name="status_awaiting_pickup">Очікує одержання</string>
   <string name="status_customs">Прибула на митницю</string>
-    <string name="status_customs_cleared">Митне оформлення завершено</string>
-    <string name="status_delivered">Доставлена</string>
+  <string name="status_customs_cleared">Митне оформлення завершено</string>
+  <string name="status_delivered">Доставлена</string>
   <string name="status_delivery_failure">Невдала доставка</string>
   <string name="status_in_transit">В дорозі</string>
   <string name="status_in_warehouse">Прибула на склад</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -56,7 +56,8 @@
   <string name="specify_postal_code_flavor_text">Додатково. Ми мложете отримати більше інформації, таку як розташування, за допомогою поштового індексу.</string>
   <string name="status_awaiting_pickup">Очікує одержання</string>
   <string name="status_customs">Прибула на митницю</string>
-  <string name="status_delivered">Доставлена</string>
+    <string name="status_customs_cleared">Митне оформлення завершено</string>
+    <string name="status_delivered">Доставлена</string>
   <string name="status_delivery_failure">Невдала доставка</string>
   <string name="status_in_transit">В дорозі</string>
   <string name="status_in_warehouse">Прибула на склад</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
   <string name="save">Save</string>
   <string name="service_an_post" translatable="false">An Post</string>
   <string name="service_belpost">Belpost</string>
+  <string name="service_cainiao" translatable="false">Cainiao</string>
   <string name="service_dhl" translatable="false">DHL</string>
   <string name="service_dpd_uk">DPD UK</string>
   <string name="service_ekart" translatable="false">eKart</string>
@@ -69,6 +70,7 @@
   <string name="specify_postal_code_flavor_text">Optional. You may be able to access extra information, such as location, with a postal code.</string>
   <string name="status_awaiting_pickup">Awaiting pickup</string>
   <string name="status_customs">Arrived at customs</string>
+  <string name="status_customs_cleared">Cleared customs</string>
   <string name="status_delivered">Delivered</string>
   <string name="status_delivery_failure">Failed to deliver</string>
   <string name="status_in_transit">In transit</string>


### PR DESCRIPTION
I've been missing the ability to track Cainiao (Aliexpress) parcels on this app which held me off from deleting my other parcel tracking app, so thought I'd have a look at adding it. Turns out it isn't that difficult!

Summary of changes:
- Added new delivery service for Cainiao deliveries in CainiaoDeliveryService.kt
- Added it to the Services enum and getDeliveryService in Core.kt
- Added a new status for when items have cleared customs but not left it yet. I don't know if you've already decided against this before so happy to remove it if you want but though I'd add it as it's a bit more clear than just 'In transit'.
- Updated readme to include Cainiao as a supported service.

I couldn't come up with any tests for this one as it seems that the tracking number can take a few formats based on the local delivery service used when the parcel arrives in the destination country, and I only have a few tracking numbers to test with from my own parcels. It will detect invalid codes in the app just fine by checking it with the API, though.

I gathered together any status codes I could find from my tracking codes and what I could find on the Aliexpress subreddit, I think most of them are covered but there may be a few uncommon ones that I didn't get. Its a bit difficult since there is no documentation for this api.

Main parcels list:
![main](https://github.com/user-attachments/assets/70ae7bbf-a05f-4a87-8ceb-87d0bdb04e9c)

Package in transit:
![in_transit](https://github.com/user-attachments/assets/336f3fa4-05b4-4f4d-9904-b4422c6a47f2)

Delivered package:
![delivered](https://github.com/user-attachments/assets/a0c0a76f-1a8c-4cf0-8237-a3e22c2ec4cb)

Invalid tracking code:
![invalid_tracking](https://github.com/user-attachments/assets/2d26ef8b-d89e-46c1-aea5-1183940d5c59)

Let me know what you think, happy to make any changes :)