### PR TITLE
add de locale to fastlane and improve formatting for other locales

### DIFF
--- a/fastlane/metadata/android/cs-CZ/full_description.txt
+++ b/fastlane/metadata/android/cs-CZ/full_description.txt
@@ -1,25 +1,31 @@
 📦 Parcel je aplikace, která vám pomáhá sledovat všechny vaše zásilky.
 
 Některé funkce aplikace:
+
 - 📱 Čisté a jednoduché rozhraní: soustřeďte se na své zásilky, ne na to, jak používat aplikaci.
 - 💬 Oznámení: získejte oznámení vždy, když se změní stav zásilky.
 - 🚫 Bez reklam a jiných nepříjemností.
 - 👥 Bezplatná a s otevřeným kódem: https://github.com/itsvic-dev/parcel
 
 --- Podporované služby ---
+
 Mezinárodní:
+
 - DHL
 - GLS
 - UPS
 
 Severní Amerika:
+
 - UniUni
 
 Velká Británie:
+
 - DPD UK
 - Evri
 
 Evropa:
+
 - An Post (IE)
 - Belpost (BY)
 - GLS Hungary
@@ -36,5 +42,6 @@ Evropa:
 - Ukrposhta (UA)
 
 Asie:
+
 - eKart (IN)
 - SPX Thailand

--- a/fastlane/metadata/android/de-DE/short_description.txt
+++ b/fastlane/metadata/android/de-DE/short_description.txt
@@ -1,0 +1,1 @@
+Verfolgen Sie alle Ihre Pakete ganz einfach.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,25 +1,31 @@
 📦 Parcel is an app that helps you keep track of all your parcels.
 
 Some of Parcel's features:
+
 - 📱 Clean and simple interface: Focus solely on your parcels, not how to use the app.
 - 💬 Notifications: Get notified every time a parcel progresses further.
 - 🚫 No ads or other annoyances.
 - 👥 Free and open-source: https://github.com/itsvic-dev/parcel
 
 --- Supported services ---
+
 International:
+
 - DHL
 - GLS
 - UPS
 
 North America:
+
 - UniUni
 
 United Kingdom:
+
 - DPD UK
 - Evri
 
 Europe:
+
 - An Post (IE)
 - Belpost (BY)
 - GLS Hungary
@@ -36,5 +42,6 @@ Europe:
 - Ukrposhta (UA)
 
 Asia:
+
 - eKart (IN)
 - SPX Thailand

--- a/fastlane/metadata/android/hu-HU/full_description.txt
+++ b/fastlane/metadata/android/hu-HU/full_description.txt
@@ -1,25 +1,31 @@
 📦 A Parcel egy app ami segít a csomagjaid nyomon követésében.
 
 Parcel néhány funkciója:
+
 - 📱 Letisztult és egyszerű felület: fókuszálj a csomagjaidra, ne az app használatának elsajátítására.
 - 💬 Értesítések: Értesülj a csomagjaid állapotának változásáról.
 - 🚫 Nincsenek reklámok vagy egyéb más zavaró dolgok.
 - 👥 Ingyenes és nyílt forráskódú: https://github.com/itsvic-dev/parcel
 
 --- Támogatott futárszolgálatok ---
+
 Nemzetközi:
+
 - DHL
 - GLS
 - UPS
 
 Észak Amerika:
+
 - UniUni
 
 Egyesült Királyság:
+
 - DPD UK
 - Evri
 
 Európa:
+
 - An Post (IE)
 - Belposta (BY)
 - Hermes (DE)
@@ -36,5 +42,6 @@ Európa:
 - Ukrposta (UA)
 
 Ázsia:
+
 - eKart (IN)
 - SPX Thaiföld

--- a/fastlane/metadata/android/pl-PL/full_description.txt
+++ b/fastlane/metadata/android/pl-PL/full_description.txt
@@ -1,25 +1,31 @@
 📦 Parcel to aplikacja, która pomaga śledzić wszystkie Twoje paczki.
 
 Niektóre funkcje Parcel:
+
 - 📱 Prosty i przejrzysty interfejs: Skup się wyłącznie na paczkach, a nie na tym, jak korzystać z aplikacji.
 - 💬 Powiadomienia: Otrzymuj powiadomienia za każdym razem, gdy paczka dotrze dalej.
 - 🚫 Żadnych reklam i innych irytacji.
 - 👥 Darmowe i otwarte oprogramowanie: https://github.com/itsvic-dev/parcel
 
 --- Obsługiwane usługi ---
+
 Międzynarodowe:
+
 - DHL
 - GLS
 - UPS
 
 Ameryka Północna:
+
 - UniUni
 
 Wielka Brytania:
+
 - DPD Wielka Brytania
 - Evri
 
 Europa:
+
 - An Post (IE)
 - Belpost (BY)
 - GLS Węgry
@@ -36,5 +42,6 @@ Europa:
 - Ukrposzta (UA)
 
 Azja:
+
 - eKart (IN)
 - SPX Tajlandia


### PR DESCRIPTION
This PR slightly improves formatting of the English full description, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds the German (de) locale, though just with a short description.

Closes #141 