### PR TITLE
fix crash for UPS due to json conversion error for null value in weightUnit

### DIFF
--- a/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
@@ -92,11 +92,11 @@ object UPSDeliveryService : DeliveryService {
           else -> logUnknownStatus("UPS", details.progressBarType!!)
         }
 
-    val metadata =
-        mutableMapOf(
-            R.string.property_weight to
-                "${details.additionalInformation!!.weight} ${details.additionalInformation.weightUnit}",
-        )
+    val metadata = mutableMapOf<Int, String>()
+    if (details.additionalInformation?.weightUnit != null) {
+      metadata[R.string.property_weight] =
+          "${details.additionalInformation.weight} ${details.additionalInformation.weightUnit}"
+    }
 
     // ETA
     if (details.scheduledDeliveryDateDetail != null && details.packageStatusTime != null) {
@@ -188,7 +188,7 @@ object UPSDeliveryService : DeliveryService {
   @JsonClass(generateAdapter = true)
   internal data class PkgMoreInfo(
       val weight: String,
-      val weightUnit: String,
+      val weightUnit: String?,
   )
 
   @JsonClass(generateAdapter = true)


### PR DESCRIPTION
fix crash for UPS due to json conversion error for null value in weightUnit

-> make the weightUnit optional (nullable) and do not list it as a metadata property in the view if it is null

closes #179 

---

For the future, defensive error handling should be added to avoid crashes caused by unversioned proprietary APIs suddenly changing
