### PR TITLE
add error handling to avoid crashes on API parsing

### DIFF
--- a/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/UPSDeliveryService.kt
@@ -32,9 +32,7 @@ object UPSDeliveryService : DeliveryService {
     val tokens = getCsrfTokens(trackingId)
 
     val language = LocaleList.getDefault().get(0)
-    val country =
-        if (language.country.isEmpty()) defaultRegionsForLanguageCode[language.language]
-        else language.country
+    val country = language.country.ifEmpty { defaultRegionsForLanguageCode[language.language] }
     val locale = "${language.language}_$country"
 
     val resp =

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,7 +18,9 @@
   <string name="dump_logs_button">Protokolle in Datei exportieren</string>
   <string name="edit">Bearbeiten</string>
   <string name="edit_parcel">Paket bearbeiten</string>
+  <string name="error_json_conversion">Beim Parsen der Serverantwort ist ein Fehler aufgetreten, möglicherweise aufgrund einer Änderung der API.\n\nFehlermeldung der JSON Konvertierung:\n%1$s</string>
   <string name="error_no_api_key_provided">Dieser Zustelldienst erfordert einen API-Schlüssel, aber es wurde keiner angegeben. Weitere Informationen finden Sie in den App-Einstellungen.</string>
+  <string name="error_unexpected_detail">Ein unbekannter Fehler ist aufgetreten mit der Nachricht:\n%1$s.</string>
   <string name="go_back">Zurück</string>
   <string name="human_name_error_text">Name darf nicht leer sein.</string>
   <string name="ignore">Ignorieren</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,9 @@
   <string name="dump_logs_button">Dump logs to file</string>
   <string name="edit">Edit</string>
   <string name="edit_parcel">Edit parcel</string>
+  <string name="error_json_conversion">There was an error parsing the response, possibly because the API changed.\n\nJSON conversion error message:\n%1$s</string>
   <string name="error_no_api_key_provided">This delivery service requires an API key, but none was provided. Check the app\'s settings for more information.</string>
+  <string name="error_unexpected_detail">An unexpected error was encountered with the message:\n%1$s.</string>
   <string name="go_back">Go back</string>
   <string name="human_name_error_text">Name must not be blank.</string>
   <string name="ignore">Ignore</string>


### PR DESCRIPTION
On JSON data conversion error or any other RuntimeException, instead of crashing and possibly creating an unremovable parcel entry, create a parcel error entry instead with an error message.

The message may also help with further troubleshooting on user reports.



<img width="397" height="330" alt="screenshot of error message" src="https://github.com/user-attachments/assets/b6e012e6-e30e-4a41-a5bd-889fc8e38829" />
