### PR TITLE
Fix Allegro OneBox tracking showing incorrect time

### DIFF
--- a/app/src/main/java/dev/itsvic/parceltracker/api/AllegroOneBoxDeliveryService.kt
+++ b/app/src/main/java/dev/itsvic/parceltracker/api/AllegroOneBoxDeliveryService.kt
@@ -3,8 +3,9 @@ package dev.itsvic.parceltracker.api
 import android.os.LocaleList
 import com.squareup.moshi.JsonClass
 import dev.itsvic.parceltracker.R
+import java.time.Instant
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.util.TimeZone
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -109,7 +110,8 @@ object AllegroOneBoxDeliveryService : DeliveryService {
     return events.map { item ->
       ParcelHistoryItem(
           item.description,
-          LocalDateTime.parse(item.eventTimestamp, DateTimeFormatter.ISO_DATE_TIME),
+          LocalDateTime.ofInstant(
+              Instant.parse(item.eventTimestamp), TimeZone.getDefault().toZoneId()),
           "" // the API doesn't provide us any locations :(
           )
     }


### PR DESCRIPTION
## Summary
- Fixes UTC timestamp being treated as local time in Allegro OneBox tracking
- Times are now correctly converted from UTC to the user's local timezone

## Changes Made
- Modified `AllegroOneBoxDeliveryService.kt` to use `Instant.parse()` + `LocalDateTime.ofInstant()` 
- This matches the pattern used in other services like `BelpostDeliveryService` and `CainiaoDeliveryService`
- Removed unused `DateTimeFormatter` import

## Technical Details
The API returns timestamps in ISO 8601 format with UTC timezone (e.g., `2024-01-15T10:30:00Z`). Previously, `LocalDateTime.parse()` was used which ignores the timezone suffix and interprets the time as local. Now we properly parse it as an `Instant` (UTC) and convert to local time.

## Test Plan
- Tested that the code compiles correctly
- The fix follows the same pattern as `localDateFromMilli()` in Core.kt

Fixes #187